### PR TITLE
feat: add GetIngredientsMissingCost operation

### DIFF
--- a/operations/GetIngredientsMissingCost.graphql
+++ b/operations/GetIngredientsMissingCost.graphql
@@ -1,0 +1,32 @@
+query GetIngredientsMissingCost(
+  $locationId: String
+  $missingCostAt: MissingCostEnum = AllLocations
+  $first: Int = 50
+  $startIndex: Int = 0
+  $orderBy: String
+  $sortDirection: SortDirectionEnum
+) {
+  viewer {
+    ingredientConnection(
+      locationId: $locationId
+      filters: {
+        isMissingCost: true
+        missingCostAt: $missingCostAt
+      }
+      paginationOptions: {
+        first: $first
+        startIndex: $startIndex
+        orderBy: $orderBy
+        sortDirection: $sortDirection
+      }
+    ) {
+      edges {
+        index
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `operations/GetIngredientsMissingCost.graphql`, a paginated query for surfacing ingredients with missing cost data — useful for catalog/data-quality workflows.
- Uses the non-deprecated `ingredientConnection` path (the deprecated `viewer.ingredients(isMissingCost:)` was available but the repo standardizes on the connection pattern).
- Supports scoping via `MissingCostEnum` so callers can check a single location (`CurrentLocation` + `locationId`) or across all locations (`AllLocations`, default).

## Test plan
- [ ] Run with `{ "missingCostAt": "AllLocations", "first": 25 }` and confirm results are all ingredients flagged as missing cost company-wide.
- [ ] Run with `{ "locationId": "<LOC_ID>", "missingCostAt": "CurrentLocation", "first": 25 }` and confirm results scope to that location.
- [ ] Verify pagination by passing non-zero `startIndex` and checking `edges[].index` increments from that offset.
- [ ] Confirm operation validates against the introspected schema on MCP server startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to query and retrieve ingredients with missing cost data, with support for location-based filtering and pagination options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->